### PR TITLE
ci: add pipeline to build/push distroless images to loadsmart registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,35 @@
 version: 2.1
 
+tag-pattern: &tag-pattern
+  only: /(^(v)?\d+\.\d+\.\d+$)|(^[0-9]{4}\.[0-9]{1,2}\.[0-9]{1,2}\.[0-9]+$)/
+
 orbs:
   lumper: loadsmart/lumper@4
+  aws-ecr: circleci/aws-ecr@9.5.2
   sentinel: loadsmart/sentinel@1
 
-commands:
-  setup-env:
+jobs:
+  build-distroless:
+    parameters:
+      push:
+        type: boolean
+        default: false
+      arch:
+        type: enum
+        default: arm64
+        enum: ['amd64', 'arm64']
+      resource_class:
+        type: string
+        default: arm.large
+    machine:
+      image: ubuntu-2004:current
+      docker_layer_caching: true
+    resource_class: << parameters.resource_class >>
+    environment:
+      ARCH: << parameters.arch >>
     steps:
+      - checkout
+
       - run:
           name: Setup Environment Variables
           command: |
@@ -14,20 +37,9 @@ commands:
             echo 'export TARBALL_PATH="/tmp/teleport-tarballs"' >> "$BASH_ENV"
             echo "export TELEPORT_VERSION=${TELEPORT_VERSION}" >> "$BASH_ENV"
 
-jobs:
-  build-distroless-arm64:
-    resource_class: arm.large
-    machine:
-      image: ubuntu-2004:current
-      docker_layer_caching: true
-    steps:
-      - checkout
-
-      - setup-env
-
       - restore_cache:
           keys:
-            - go-build-cache-v1-{{ arch }}-{{ checksum "go.sum" }}
+            - go-cache-v1-{{ arch }}-{{ checksum "go.sum" }}
 
       - run:
           name: Build Teleport Binaries
@@ -37,39 +49,67 @@ jobs:
             make docker-binaries
 
       - save_cache:
-          key: go-build-cache-v1-{{ arch }}-{{ checksum "go.sum" }}
+          key: go-cache-v1-{{ arch }}-{{ checksum "go.sum" }}
           paths:
             - ~/.cache/go
+
+      - run:
+          name: Build Tarball
+          command: |
+            make build-archive
 
       - run:
           name: Prepare Artifacts
           command: |
             mkdir -p ${TARBALL_PATH}
-            cp teleport-${TELEPORT_VERSION}-linux-arm64-bin.tar.gz ${TARBALL_PATH}/
+            cp teleport-v${TELEPORT_VERSION}-linux-${ARCH}-bin.tar.gz ${TARBALL_PATH}/
             cp build.assets/charts/fetch-debs build/fetch-debs
             cp build.assets/charts/Dockerfile-distroless build/Dockerfile
 
       - run:
-          name: Build debian package
+          name: Build Debian Package
           command: |
-            make build-archive
             make deb
 
       - run:
-          name: Build ARM64 Distroless Docker Image
+          name: Build Distroless Docker Image
           command: |
             docker buildx build \
               -f build/Dockerfile \
-              --platform linux/arm64 \
+              --platform linux/${ARCH} \
               --build-arg TELEPORT_VERSION=${TELEPORT_VERSION} \
               --build-arg TELEPORT_RELEASE_INFIX= \
-              -t loadsmart/teleport:${TELEPORT_VERSION}-arm64 build
+              -t ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/platform/teleport:${TELEPORT_VERSION}-${ARCH} build
+
+      - when:
+          condition: << parameters.push >>
+          steps:
+            - aws-ecr/ecr_login
+            - aws-ecr/push_image:
+                repo: platform/teleport
+                tag: '${TELEPORT_VERSION}-${ARCH}'
 
 workflows:
+  build:
+    jobs:
+      - build-distroless:
+          context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+
   build-and-push:
     jobs:
-      - build-distroless-arm64:
+      - build-distroless:
+          name: build-and-push-distroless
           context: org-global
+          push: true
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              <<: *tag-pattern
 
   developer-productivity:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,77 @@
 version: 2.1
 
-# Define the jobs we want to run for this project
-jobs:
-  build:
-    docker:
-      - image: cimg/base:2023.03
-    steps:
-      - checkout
-      - run: echo "this is the build job"
-  test:
-    docker:
-      - image: cimg/base:2023.03
-    steps:
-      - checkout
-      - run: echo "this is the test job"
+orbs:
+  lumper: loadsmart/lumper@4
+  sentinel: loadsmart/sentinel@1
 
-# Orchestrate our job run sequence
+commands:
+  setup-env:
+    steps:
+      - run:
+          name: Setup Environment Variables
+          command: |
+            TELEPORT_VERSION=$(make print-version)
+            echo 'export TARBALL_PATH="/tmp/teleport-tarballs"' >> "$BASH_ENV"
+            echo "export TELEPORT_VERSION=${TELEPORT_VERSION}" >> "$BASH_ENV"
+
+jobs:
+  build-distroless-arm64:
+    resource_class: arm.large
+    machine:
+      image: ubuntu-2004:current
+      docker_layer_caching: true
+    steps:
+      - checkout
+
+      - setup-env
+
+      - restore_cache:
+          keys:
+            - go-build-cache-v1-{{ arch }}-{{ checksum "go.sum" }}
+
+      - run:
+          name: Build Teleport Binaries
+          command: |
+            export GOCACHE="$HOME/.cache/go"
+            mkdir -p "$GOCACHE"
+            make docker-binaries
+
+      - save_cache:
+          key: go-build-cache-v1-{{ arch }}-{{ checksum "go.sum" }}
+          paths:
+            - ~/.cache/go
+
+      - run:
+          name: Prepare Artifacts
+          command: |
+            mkdir -p ${TARBALL_PATH}
+            cp teleport-${TELEPORT_VERSION}-linux-arm64-bin.tar.gz ${TARBALL_PATH}/
+            cp build.assets/charts/fetch-debs build/fetch-debs
+            cp build.assets/charts/Dockerfile-distroless build/Dockerfile
+
+      - run:
+          name: Build debian package
+          command: |
+            make build-archive
+            make deb
+
+      - run:
+          name: Build ARM64 Distroless Docker Image
+          command: |
+            docker buildx build \
+              -f build/Dockerfile \
+              --platform linux/arm64 \
+              --build-arg TELEPORT_VERSION=${TELEPORT_VERSION} \
+              --build-arg TELEPORT_RELEASE_INFIX= \
+              -t loadsmart/teleport:${TELEPORT_VERSION}-arm64 build
+
 workflows:
-  build_and_test:
+  build-and-push:
     jobs:
-      - build
-      - test
+      - build-distroless-arm64:
+          context: org-global
+
+  developer-productivity:
+    jobs:
+      - sentinel/default:
+          context: org-global

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,1 @@
-# Merge rules are governed by logic in the Workflow Bot. Protect the
-# .github/workflows directory (and the merge logic) using CODEOWNERS.
-/.github/workflows/ @klizhentas @russjones @r0mant @zmb3 @fheinecke @camscale @tcsc @rosstimothy
-/build.assets/tooling/cmd/difftest/ @klizhentas @russjones @r0mant @zmb3
-
-# Owners for dependency updates in JS packages.
-/pnpm-lock.yaml @avatus @gzdunek @ravicious
-web/packages/teleterm/package.json @gzdunek @ravicious
+*   @loadsmart/platform-operations

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,5 @@ msgfile/
 
 # Dockerized builds generate .pnpm-store in the root, so ignore it
 .pnpm-store
+
+.terraform.lock.hcl

--- a/Makefile
+++ b/Makefile
@@ -481,6 +481,7 @@ endif
 .PHONY: rdpclient
 rdpclient:
 ifeq ("$(with_rdpclient)", "yes")
+	cargo clean
 	$(RDPCLIENT_ENV) \
 		cargo build -p rdp-client $(if $(FIPS),--features=fips) --release --locked $(CARGO_TARGET)
 endif

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> This fork is maintained by Loadsmart to compile Teleport CE from source under the AGPLv3 license to avoid the commercial restrictions of the Apache 2.0-licensed binaries. A CircleCI-powered pipeline automates the compilation, builds a distroless image, and pushes it to a private registry.
+
 Teleport provides connectivity, authentication, access controls and audit for infrastructure.
 
 Here is why you might use Teleport:

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -76,7 +76,7 @@ build: buildbox-centos7 webassets
 .PHONY:build-binaries
 build-binaries: buildbox-centos7 webassets
 	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7) \
-		make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' PIV=$(PIV) full
+		scl enable $(DEVTOOLSET) "make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' PIV=$(PIV) full"
 
 #
 # Build 'teleport' Enterprise release inside a docker container

--- a/terraform/general/circleci.tf
+++ b/terraform/general/circleci.tf
@@ -1,0 +1,45 @@
+module "circleci" {
+  source = "git@github.com:loadsmart/terraform-modules.git//circleci-app"
+
+  project = local.project
+
+  allow_aws_access = true
+
+  providers = {
+    aws.main = aws
+    aws.dev  = aws.dev
+  }
+}
+
+data "aws_iam_policy_document" "ecr_push" {
+  statement {
+    sid = "AllowPushToECR"
+
+    actions = [
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:PutImage",
+    ]
+
+    resources = [
+      module.ecr_teleport.arn,
+      "${module.ecr_teleport.arn}/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ecr_push" {
+  name   = "circleci-teleport-ECRPusher"
+  policy = data.aws_iam_policy_document.ecr_push.json
+}
+
+resource "aws_iam_user_policy_attachment" "ecr_push" {
+  user       = module.circleci.user_name
+  policy_arn = aws_iam_policy.ecr_push.arn
+}
+
+resource "aws_iam_user_policy_attachment" "ecr_readonly" {
+  user       = module.circleci.user_name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}

--- a/terraform/general/config.tf
+++ b/terraform/general/config.tf
@@ -1,0 +1,11 @@
+terraform {
+  backend "s3" {
+    bucket         = "loadsmart-terraform"
+    key            = "teleport/general/terraform.tfstate"
+    region         = "us-east-1"
+    encrypt        = true
+    kms_key_id     = "arn:aws:kms:us-east-1:845156828388:key/a18b304d-d85b-4deb-b5b2-67771cff721a"
+    dynamodb_table = "terraform_locks"
+    profile        = "loadsmart-main"
+  }
+}

--- a/terraform/general/ecr.tf
+++ b/terraform/general/ecr.tf
@@ -1,0 +1,6 @@
+module "ecr_teleport" {
+  source = "git@github.com:loadsmart/terraform-modules.git//aws-ecr"
+
+  project = "platform/teleport"
+  squad   = local.squad
+}

--- a/terraform/general/locals.tf
+++ b/terraform/general/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  project = "teleport"
+  squad   = "platform-operations"
+}

--- a/terraform/general/providers.tf
+++ b/terraform/general/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region  = "us-east-1"
+  profile = "loadsmart-main"
+}
+
+provider "aws" {
+  alias   = "dev"
+  region  = "us-east-1"
+  profile = "loadsmart-dev"
+}

--- a/terraform/general/versions.tf
+++ b/terraform/general/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.14"
+}


### PR DESCRIPTION
## Motivation and context for the change

<!--
Describe the motivation against creating this change and, if applicable, describe the current behavior and any relevant screenshots or diagrams (if applicable).
-->

Teleport CE's license change (v16+) restricts commercial use of prebuilt binaries and containers. Loadsmart must build and use its own binaries from AGPLv3 source to remain compliant and maintain secure infrastructure access.


## A clear description of the change

<!--
Describe the change, including new behavior, possible impacts, and any relevant screenshots or diagrams (if applicable).
-->

Adds a CircleCI pipeline to:
- Build Loadsmart's own Teleport binaries from AGPLv3 source
- Build a distroless container image
- Push the image to a private ECR

Also, the PR includes fixes for build errors and Terraform code for CircleCI/ECR configuration.

## Testing

<!--
Inform whether or not the change is covered with automated tests.
-->

- [x] The change is covered with automated tests

#### Testing instructions

<!--
If the change isn't covered with automated tests, provide a detailed list of steps for the reviewer to test it. You may remove this section in case of automated tests.
-->

## Rollback

- [x] The change can be automatically rolled back

#### Rollback instructions

<!--
If the rollback cannot be performed automatically, provide a detailed list of the steps needed to complete a rollback. Add any relevant link to the documentation if applicable. You may remove this section in case of support for automated rollback.
-->
