### PR TITLE
chore: add release script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ tag-pattern: &tag-pattern
 orbs:
   lumper: loadsmart/lumper@4
   aws-ecr: circleci/aws-ecr@9.5.2
-  sentinel: loadsmart/sentinel@1
 
 jobs:
   build-distroless:
@@ -98,6 +97,7 @@ workflows:
             branches:
               ignore:
                 - master
+                - release/*
 
   build-and-push:
     jobs:
@@ -110,8 +110,3 @@ workflows:
               ignore: /.*/
             tags:
               <<: *tag-pattern
-
-  developer-productivity:
-    jobs:
-      - sentinel/default:
-          context: org-global

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> This fork is maintained by Loadsmart to compile Teleport CE from source under the AGPLv3 license to avoid the commercial restrictions of the Apache 2.0-licensed binaries. A CircleCI-powered pipeline automates the compilation, builds a distroless image, and pushes it to a private registry.
+> This fork is maintained by Loadsmart to compile Teleport CE from source under the AGPLv3 license to avoid the commercial restrictions of the Apache 2.0-licensed binaries. A CircleCI-powered pipeline automates the compilation, builds a distroless image, and pushes it to a private registry. See the [Confluence page](https://loadsmart.atlassian.net/wiki/spaces/PLATFORMOPERATIONS/pages/2776891393/Teleport+Management#How-to-upgrade-Teleport).
 
 Teleport provides connectivity, authentication, access controls and audit for infrastructure.
 

--- a/loadsmart/Makefile
+++ b/loadsmart/Makefile
@@ -1,0 +1,8 @@
+# Prepares a custom Loadmart Teleport release to trigger the CircleCI pipeline and push the image to the Loadsmart ECR registry.
+.PHONY: release
+release:
+	@if [ -z "$(VERSION)" ]; then \
+		echo "Error: VERSION is not set. Usage: make ls-release VERSION=17.5.1"; \
+		exit 1; \
+	fi
+	@./release.sh $(VERSION)

--- a/loadsmart/release.sh
+++ b/loadsmart/release.sh
@@ -6,7 +6,11 @@ if [[ $# -ne 1 ]]; then
   exit 1
 fi
 
-VERSION=v"$1"
+VERSION="$1"
+if [[ "${VERSION}" != v* ]]; then
+  VERSION="v${VERSION}"
+fi
+
 BRANCH="release/$VERSION"
 PATCH_FILE="loadsmart.patch"
 FILES_TO_PATCH=".circleci/config.yml Makefile build.assets/Makefile"

--- a/loadsmart/release.sh
+++ b/loadsmart/release.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <version> (e.g., 17.5.1)"
+  exit 1
+fi
+
+VERSION=v"$1"
+BRANCH="release/$VERSION"
+PATCH_FILE="loadsmart.patch"
+FILES_TO_PATCH=".circleci/config.yml Makefile build.assets/Makefile"
+UPSTREAM_URL="https://github.com/gravitational/teleport.git"
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo "> Adding upstream remote..."
+if ! git remote get-url upstream &>/dev/null; then
+  git remote add upstream ${UPSTREAM_URL}
+fi
+
+echo "> Fetching upstream..."
+git fetch upstream --no-tags
+git fetch upstream +refs/tags/"${VERSION}":refs/tags/"${VERSION}" --no-tags
+
+echo "Creating new branch from upstream tag: ${VERSION}..."
+git checkout tags/"${VERSION}" -B "${BRANCH}"
+
+echo "> Generating patch from loadsmart..."
+git format-patch "$(git merge-base upstream/master master)"..master --stdout -- ${FILES_TO_PATCH} >"${PATCH_FILE}"
+
+echo "> Applying patch..."
+git am $PATCH_FILE
+
+echo "> Tagging patched release as $VERSION..."
+git tag "${VERSION}" --force
+git push origin "${BRANCH}"
+git push origin refs/tags/"${VERSION}" --force
+
+echo "> Push complete. A CircleCI pipeline should now be triggered at: https://app.circleci.com/pipelines/github/loadsmart/teleport?branch=${BRANCH}"


### PR DESCRIPTION
## Motivation and context for the change

<!--
Describe the motivation against creating this change and, if applicable, describe the current behavior and any relevant screenshots or diagrams (if applicable).
-->

This PR introduces a release script that automates the creation of a custom release based on an official Teleport CE release. The script applies a patch to add a CircleCI configuration, triggers the pipeline to compile binaries, and pushes the resulting image to the Loadsmart private registry.

```
make -C loadsmart release VERSION=x.y.z
```

PLATFORM-6535

## A clear description of the change

<!--
Describe the change, including new behavior, possible impacts, and any relevant screenshots or diagrams (if applicable).
-->

- add release script
- remove sentinel job to prevent patch conflicts
- update README

## Testing

<!--
Inform whether or not the change is covered with automated tests.
-->

- [x] The change is covered with automated tests

#### Testing instructions

<!--
If the change isn't covered with automated tests, provide a detailed list of steps for the reviewer to test it. You may remove this section in case of automated tests.
-->

## Rollback

- [x] The change can be automatically rolled back

#### Rollback instructions

<!--
If the rollback cannot be performed automatically, provide a detailed list of the steps needed to complete a rollback. Add any relevant link to the documentation if applicable. You may remove this section in case of support for automated rollback.
-->
