### PR TITLE
ci: add separate jobs for arm64 and amd64 builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,15 @@ jobs:
           name: Setup Environment Variables
           command: |
             TELEPORT_VERSION=$(make print-version)
+            if [ "${ARCH}" = "arm64" ]; then
+              TAG_SUFFIX="-arm64"
+            else
+              TAG_SUFFIX=""
+            fi
+            echo "TAG_SUFFIX=${TAG_SUFFIX}" >> $BASH_ENV
             echo 'export TARBALL_PATH="/tmp/teleport-tarballs"' >> "$BASH_ENV"
             echo "export TELEPORT_VERSION=${TELEPORT_VERSION}" >> "$BASH_ENV"
+
 
       - restore_cache:
           keys:
@@ -78,7 +85,7 @@ jobs:
               --platform linux/${ARCH} \
               --build-arg TELEPORT_VERSION=${TELEPORT_VERSION} \
               --build-arg TELEPORT_RELEASE_INFIX= \
-              -t ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/platform/teleport:${TELEPORT_VERSION}-${ARCH} build
+              -t ${AWS_ACCOUNT_ID}.dkr.ecr.us-east-1.amazonaws.com/platform/teleport:${TELEPORT_VERSION}${TAG_SUFFIX} build
 
       - when:
           condition: << parameters.push >>
@@ -86,13 +93,24 @@ jobs:
             - aws-ecr/ecr_login
             - aws-ecr/push_image:
                 repo: platform/teleport
-                tag: '${TELEPORT_VERSION}-${ARCH}'
+                tag: '${TELEPORT_VERSION}${TAG_SUFFIX}'
 
 workflows:
   build:
     jobs:
       - build-distroless:
+          name: build-distroless-arm64
           context: org-global
+          filters:
+            branches:
+              ignore:
+                - master
+                - release/*
+      - build-distroless:
+          name: build-distroless-amd64
+          context: org-global
+          arch: amd64
+          resource_class: large
           filters:
             branches:
               ignore:
@@ -102,8 +120,19 @@ workflows:
   build-and-push:
     jobs:
       - build-distroless:
-          name: build-and-push-distroless
+          name: build-and-push-distroless-arm64
           context: org-global
+          push: true
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              <<: *tag-pattern
+      - build-distroless:
+          name: build-and-push-distroless-amd64
+          context: org-global
+          arch: amd64
+          resource_class: large
           push: true
           filters:
             branches:


### PR DESCRIPTION
## Motivation and context for the change

<!--
Describe the motivation against creating this change and, if applicable, describe the current behavior and any relevant screenshots or diagrams (if applicable).
-->

Add separated CircleCI jobs to build and push distroless images for both arm64 and amd64 arch, including resource class and arch specification for both.

## A clear description of the change

<!--
Describe the change, including new behavior, possible impacts, and any relevant screenshots or diagrams (if applicable).
-->

- Add distinct CircleCI jobs for `amd64` image builds.
- Ensures both architectures are built and pushed independently.

## Testing

<!--
Inform whether or not the change is covered with automated tests.
-->

- [x] The change is covered with automated tests

#### Testing instructions

<!--
If the change isn't covered with automated tests, provide a detailed list of steps for the reviewer to test it. You may remove this section in case of automated tests.
-->

## Rollback

- [x] The change can be automatically rolled back

#### Rollback instructions

<!--
If the rollback cannot be performed automatically, provide a detailed list of the steps needed to complete a rollback. Add any relevant link to the documentation if applicable. You may remove this section in case of support for automated rollback.
-->
