### PR TITLE
build: add libfido2-1 dependency to Dockerfiles for ARM and distroles…

### DIFF
--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -30,6 +30,7 @@ RUN apt-get -y update && \
         gzip \
         libc6-dev \
         libpam-dev \
+        libfido2-1 \
         locales \
         pkg-config \
         sudo \

--- a/build.assets/charts/Dockerfile-distroless
+++ b/build.assets/charts/Dockerfile-distroless
@@ -3,7 +3,7 @@ ARG BASE_IMAGE=gcr.io/distroless/cc-debian12
 FROM debian:12 AS staging
 RUN apt-get update
 COPY fetch-debs ./
-RUN ./fetch-debs dumb-init libpam0g libaudit1 libcap-ng0
+RUN ./fetch-debs dumb-init libpam0g libaudit1 libcap-ng0 libfido2-1
 
 FROM debian:12 AS teleport
 # Install the teleport binary from an architecture-specific debian package. Note


### PR DESCRIPTION
## Motivation and context for the change

Currently, when running the tctl command inside the container, it fails because it is missing a required library.

## A clear description of the change

Add the missing library to the Dockerfile to build the image correctly

## Testing

<!--
Inform whether or not the change is covered with automated tests.
-->

- [x] The change is covered with automated tests

#### Testing instructions

<!--
If the change isn't covered with automated tests, provide a detailed list of steps for the reviewer to test it. You may remove this section in case of automated tests.
-->

## Rollback

- [x] The change can be automatically rolled back

#### Rollback instructions

<!--
If the rollback cannot be performed automatically, provide a detailed list of the steps needed to complete a rollback. Add any relevant link to the documentation if applicable. You may remove this section in case of support for automated rollback.
-->
